### PR TITLE
Implement RESTful clinic API with clean architecture

### DIFF
--- a/CP_05/Application/Common/OperationResult.cs
+++ b/CP_05/Application/Common/OperationResult.cs
@@ -1,0 +1,48 @@
+namespace CP_05.Application.Common;
+
+public enum OperationErrorType
+{
+    None = 0,
+    NotFound,
+    Validation,
+    Conflict,
+    Unknown
+}
+
+public class OperationResult
+{
+    protected OperationResult(bool isSuccess, OperationErrorType errorType, IEnumerable<string> errors)
+    {
+        IsSuccess = isSuccess;
+        ErrorType = errorType;
+        Errors = errors.ToArray();
+    }
+
+    public bool IsSuccess { get; }
+
+    public OperationErrorType ErrorType { get; }
+
+    public IReadOnlyCollection<string> Errors { get; }
+
+    public static OperationResult Success() => new(true, OperationErrorType.None, Array.Empty<string>());
+
+    public static OperationResult Failure(OperationErrorType errorType, params string[] errors)
+        => new(false, errorType, errors);
+}
+
+public class OperationResult<T> : OperationResult
+{
+    private OperationResult(bool isSuccess, OperationErrorType errorType, T? data, IEnumerable<string> errors)
+        : base(isSuccess, errorType, errors)
+    {
+        Data = data;
+    }
+
+    public T? Data { get; }
+
+    public static OperationResult<T> Success(T data)
+        => new(true, OperationErrorType.None, data, Array.Empty<string>());
+
+    public static OperationResult<T> Failure(OperationErrorType errorType, params string[] errors)
+        => new(false, errorType, default, errors);
+}

--- a/CP_05/Application/Dtos/Clinica/ClinicaCreateDto.cs
+++ b/CP_05/Application/Dtos/Clinica/ClinicaCreateDto.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using CP_05.Application.Dtos.Endereco;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CP_05.Application.Dtos.Clinica;
+
+[SwaggerSchema(Description = "Dados para cadastrar uma nova clínica.")]
+public class ClinicaCreateDto
+{
+    [Required]
+    [SwaggerSchema(Description = "Nome da clínica.", Example = "Clínica Bem-Estar")]
+    public string Nome { get; set; } = string.Empty;
+
+    [Required, EmailAddress]
+    [SwaggerSchema(Description = "E-mail da clínica.", Example = "contato@bemestar.com")]
+    public string Email { get; set; } = string.Empty;
+
+    [SwaggerSchema(Description = "Telefone de contato.", Example = "+55 11 4002-8922")]
+    public string? Telefone { get; set; }
+
+    [SwaggerSchema(Description = "Endereço completo da clínica.")]
+    public EnderecoCreateDto? Endereco { get; set; }
+}

--- a/CP_05/Application/Dtos/Clinica/ClinicaReadDto.cs
+++ b/CP_05/Application/Dtos/Clinica/ClinicaReadDto.cs
@@ -1,0 +1,15 @@
+using CP_05.Application.Dtos.Endereco;
+using CP_05.Application.Dtos.Profissional;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CP_05.Application.Dtos.Clinica;
+
+[SwaggerSchema(Description = "Clínica retornada pela API.")]
+public record ClinicaReadDto(
+    int Id,
+    string Nome,
+    string Email,
+    string? Telefone,
+    EnderecoReadDto? Endereco,
+    IReadOnlyCollection<ProfissionalReadDto> Profissionais
+);

--- a/CP_05/Application/Dtos/Clinica/ClinicaUpdateDto.cs
+++ b/CP_05/Application/Dtos/Clinica/ClinicaUpdateDto.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using CP_05.Application.Dtos.Endereco;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CP_05.Application.Dtos.Clinica;
+
+[SwaggerSchema(Description = "Dados para atualizar uma clínica existente.")]
+public class ClinicaUpdateDto
+{
+    [Required]
+    [SwaggerSchema(Description = "Nome da clínica.", Example = "Clínica Bem-Estar Unidade Jardins")]
+    public string Nome { get; set; } = string.Empty;
+
+    [Required, EmailAddress]
+    [SwaggerSchema(Description = "E-mail da clínica.", Example = "contato@bemestar.com")]
+    public string Email { get; set; } = string.Empty;
+
+    [SwaggerSchema(Description = "Telefone de contato.", Example = "+55 11 98877-6655")]
+    public string? Telefone { get; set; }
+
+    [SwaggerSchema(Description = "Endereço completo da clínica (enviar nulo para remover).")]
+    public EnderecoUpdateDto? Endereco { get; set; }
+}

--- a/CP_05/Application/Dtos/Endereco/EnderecoCreateDto.cs
+++ b/CP_05/Application/Dtos/Endereco/EnderecoCreateDto.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CP_05.Application.Dtos.Endereco;
+
+[SwaggerSchema(Description = "Dados para cadastrar o endereço da clínica.")]
+public class EnderecoCreateDto
+{
+    [Required]
+    [SwaggerSchema(Description = "Nome da rua.", Example = "Av. Paulista")]
+    public string Rua { get; set; } = string.Empty;
+
+    [Required]
+    [Range(1, int.MaxValue, ErrorMessage = "O número deve ser positivo.")]
+    [SwaggerSchema(Description = "Número do endereço.", Example = 1000)]
+    public int Numero { get; set; }
+
+    [Required]
+    [SwaggerSchema(Description = "Bairro da clínica.", Example = "Bela Vista")]
+    public string Bairro { get; set; } = string.Empty;
+
+    [Required]
+    [SwaggerSchema(Description = "CEP no formato brasileiro.", Example = "01310-100")]
+    public string Cep { get; set; } = string.Empty;
+}

--- a/CP_05/Application/Dtos/Endereco/EnderecoReadDto.cs
+++ b/CP_05/Application/Dtos/Endereco/EnderecoReadDto.cs
@@ -1,0 +1,12 @@
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CP_05.Application.Dtos.Endereco;
+
+[SwaggerSchema(Description = "Endereço associado à clínica.")]
+public record EnderecoReadDto(
+    int Id,
+    string Rua,
+    int Numero,
+    string Bairro,
+    string Cep
+);

--- a/CP_05/Application/Dtos/Endereco/EnderecoUpdateDto.cs
+++ b/CP_05/Application/Dtos/Endereco/EnderecoUpdateDto.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CP_05.Application.Dtos.Endereco;
+
+[SwaggerSchema(Description = "Dados para atualizar o endereço da clínica.")]
+public class EnderecoUpdateDto
+{
+    [Required]
+    [SwaggerSchema(Description = "Nome da rua.", Example = "Av. Brigadeiro Faria Lima")]
+    public string Rua { get; set; } = string.Empty;
+
+    [Required]
+    [Range(1, int.MaxValue, ErrorMessage = "O número deve ser positivo.")]
+    [SwaggerSchema(Description = "Número do endereço.", Example = 4500)]
+    public int Numero { get; set; }
+
+    [Required]
+    [SwaggerSchema(Description = "Bairro da clínica.", Example = "Itaim Bibi")]
+    public string Bairro { get; set; } = string.Empty;
+
+    [Required]
+    [SwaggerSchema(Description = "CEP no formato brasileiro.", Example = "04538-132")]
+    public string Cep { get; set; } = string.Empty;
+}

--- a/CP_05/Application/Dtos/Profissional/ProfissionalCreateDto.cs
+++ b/CP_05/Application/Dtos/Profissional/ProfissionalCreateDto.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CP_05.Application.Dtos.Profissional;
+
+[SwaggerSchema(Description = "Dados para cadastrar um profissional em uma clínica.")]
+public class ProfissionalCreateDto
+{
+    [Required]
+    [SwaggerSchema(Description = "Nome completo do profissional.", Example = "Maria Souza")]
+    public string Nome { get; set; } = string.Empty;
+
+    [Required, EmailAddress]
+    [SwaggerSchema(Description = "E-mail de contato.", Example = "maria.souza@exemplo.com")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [Range(18, 120, ErrorMessage = "A idade deve estar entre 18 e 120 anos.")]
+    [SwaggerSchema(Description = "Idade do profissional.", Example = 32)]
+    public int Idade { get; set; }
+
+    [SwaggerSchema(Description = "Cargo exercido na clínica.", Example = "Fisioterapeuta")]
+    public string? Cargo { get; set; }
+}

--- a/CP_05/Application/Dtos/Profissional/ProfissionalReadDto.cs
+++ b/CP_05/Application/Dtos/Profissional/ProfissionalReadDto.cs
@@ -1,0 +1,13 @@
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CP_05.Application.Dtos.Profissional;
+
+[SwaggerSchema(Description = "Profissional associado à clínica.")]
+public record ProfissionalReadDto(
+    int Id,
+    string Nome,
+    string Email,
+    int Idade,
+    string? Cargo,
+    int ClinicaId
+);

--- a/CP_05/Application/Dtos/Profissional/ProfissionalUpdateDto.cs
+++ b/CP_05/Application/Dtos/Profissional/ProfissionalUpdateDto.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace CP_05.Application.Dtos.Profissional;
+
+[SwaggerSchema(Description = "Dados para atualizar um profissional existente.")]
+public class ProfissionalUpdateDto
+{
+    [Required]
+    [SwaggerSchema(Description = "Nome completo do profissional.", Example = "Maria Souza")]
+    public string Nome { get; set; } = string.Empty;
+
+    [Required, EmailAddress]
+    [SwaggerSchema(Description = "E-mail de contato.", Example = "maria.souza@exemplo.com")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [Range(18, 120, ErrorMessage = "A idade deve estar entre 18 e 120 anos.")]
+    [SwaggerSchema(Description = "Idade do profissional.", Example = 33)]
+    public int Idade { get; set; }
+
+    [SwaggerSchema(Description = "Cargo exercido na clínica.", Example = "Coordenadora Clínica")]
+    public string? Cargo { get; set; }
+}

--- a/CP_05/Application/Interfaces/IClinicaUseCase.cs
+++ b/CP_05/Application/Interfaces/IClinicaUseCase.cs
@@ -1,6 +1,16 @@
-﻿namespace CP_05.Application.Interfaces
+using CP_05.Application.Common;
+using CP_05.Application.Dtos.Clinica;
+using CP_05.Application.Dtos.Profissional;
+
+namespace CP_05.Application.Interfaces;
+
+public interface IClinicaUseCase
 {
-    public interface IClinicaUseCase
-    {
-    }
+    Task<OperationResult<IEnumerable<ClinicaReadDto>>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<OperationResult<ClinicaReadDto>> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<OperationResult<ClinicaReadDto>> CreateAsync(ClinicaCreateDto dto, CancellationToken cancellationToken = default);
+    Task<OperationResult> UpdateAsync(int id, ClinicaUpdateDto dto, CancellationToken cancellationToken = default);
+    Task<OperationResult> DeleteAsync(int id, CancellationToken cancellationToken = default);
+    Task<OperationResult<ProfissionalReadDto>> AddProfissionalAsync(int clinicaId, ProfissionalCreateDto dto, CancellationToken cancellationToken = default);
+    Task<OperationResult> UpdateProfissionalAsync(int clinicaId, int profissionalId, ProfissionalUpdateDto dto, CancellationToken cancellationToken = default);
 }

--- a/CP_05/Application/Mappers/ClinicaMapper.cs
+++ b/CP_05/Application/Mappers/ClinicaMapper.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using CP_05.Application.Dtos.Clinica;
+using CP_05.Application.Dtos.Endereco;
+using CP_05.Application.Dtos.Profissional;
+using CP_05.Domain.Entities;
+
+namespace CP_05.Application.Mappers;
+
+public static class ClinicaMapper
+{
+    public static ClinicaEntity ToEntity(this ClinicaCreateDto dto)
+    {
+        var clinica = new ClinicaEntity
+        {
+            Nome = dto.Nome,
+            Email = dto.Email,
+            Telefone = dto.Telefone
+        };
+
+        if (dto.Endereco is not null)
+        {
+            clinica.Endereco = new EnderecoEntity
+            {
+                Rua = dto.Endereco.Rua,
+                Numero = dto.Endereco.Numero,
+                Bairro = dto.Endereco.Bairro,
+                Cep = dto.Endereco.Cep
+            };
+        }
+
+        return clinica;
+    }
+
+    public static void ApplyUpdate(this ClinicaEntity entity, ClinicaUpdateDto dto)
+    {
+        entity.Nome = dto.Nome;
+        entity.Email = dto.Email;
+        entity.Telefone = dto.Telefone;
+
+        if (dto.Endereco is null)
+        {
+            return;
+        }
+
+        if (entity.Endereco is null)
+        {
+            entity.Endereco = new EnderecoEntity
+            {
+                Rua = dto.Endereco.Rua,
+                Numero = dto.Endereco.Numero,
+                Bairro = dto.Endereco.Bairro,
+                Cep = dto.Endereco.Cep,
+                ClinicaId = entity.Id
+            };
+        }
+        else
+        {
+            entity.Endereco.Rua = dto.Endereco.Rua;
+            entity.Endereco.Numero = dto.Endereco.Numero;
+            entity.Endereco.Bairro = dto.Endereco.Bairro;
+            entity.Endereco.Cep = dto.Endereco.Cep;
+        }
+    }
+
+    public static ClinicaReadDto ToReadDto(this ClinicaEntity entity)
+    {
+        var enderecoDto = entity.Endereco is null
+            ? null
+            : new EnderecoReadDto(entity.Endereco.Id, entity.Endereco.Rua, entity.Endereco.Numero, entity.Endereco.Bairro, entity.Endereco.Cep);
+
+        var profissionais = entity.Profissionais
+            .Select(p => new ProfissionalReadDto(p.Id, p.Nome, p.Email, p.Idade, p.Cargo, p.ClinicaId))
+            .ToList();
+
+        return new ClinicaReadDto(entity.Id, entity.Nome, entity.Email, entity.Telefone, enderecoDto, profissionais);
+    }
+}

--- a/CP_05/Application/Mappers/ProfissionalMapper.cs
+++ b/CP_05/Application/Mappers/ProfissionalMapper.cs
@@ -1,0 +1,27 @@
+using CP_05.Application.Dtos.Profissional;
+using CP_05.Domain.Entities;
+
+namespace CP_05.Application.Mappers;
+
+public static class ProfissionalMapper
+{
+    public static ProfissionalEntity ToEntity(this ProfissionalCreateDto dto, int clinicaId) => new()
+    {
+        Nome = dto.Nome,
+        Email = dto.Email,
+        Idade = dto.Idade,
+        Cargo = dto.Cargo,
+        ClinicaId = clinicaId
+    };
+
+    public static void ApplyUpdate(this ProfissionalEntity entity, ProfissionalUpdateDto dto)
+    {
+        entity.Nome = dto.Nome;
+        entity.Email = dto.Email;
+        entity.Idade = dto.Idade;
+        entity.Cargo = dto.Cargo;
+    }
+
+    public static ProfissionalReadDto ToReadDto(this ProfissionalEntity entity)
+        => new(entity.Id, entity.Nome, entity.Email, entity.Idade, entity.Cargo, entity.ClinicaId);
+}

--- a/CP_05/Application/UseCases/ClinicaUseCase.cs
+++ b/CP_05/Application/UseCases/ClinicaUseCase.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using CP_05.Application.Common;
+using CP_05.Application.Dtos.Clinica;
+using CP_05.Application.Dtos.Profissional;
+using CP_05.Application.Interfaces;
+using CP_05.Application.Mappers;
+using CP_05.Domain.Interfaces;
+
+namespace CP_05.Application.UseCases;
+
+public class ClinicaUseCase(IClinicaRepository repository) : IClinicaUseCase
+{
+    private readonly IClinicaRepository _repository = repository;
+
+    public async Task<OperationResult<IEnumerable<ClinicaReadDto>>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var clinicas = await _repository.GetAllAsync(cancellationToken);
+        var data = clinicas.Select(c => c.ToReadDto()).ToList();
+        return OperationResult<IEnumerable<ClinicaReadDto>>.Success(data);
+    }
+
+    public async Task<OperationResult<ClinicaReadDto>> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var clinica = await _repository.GetByIdAsync(id, cancellationToken);
+        return clinica is null
+            ? OperationResult<ClinicaReadDto>.Failure(OperationErrorType.NotFound, "Clínica não encontrada.")
+            : OperationResult<ClinicaReadDto>.Success(clinica.ToReadDto());
+    }
+
+    public async Task<OperationResult<ClinicaReadDto>> CreateAsync(ClinicaCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        var entity = dto.ToEntity();
+        var created = await _repository.AddAsync(entity, cancellationToken);
+        return OperationResult<ClinicaReadDto>.Success(created.ToReadDto());
+    }
+
+    public async Task<OperationResult> UpdateAsync(int id, ClinicaUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        var clinica = await _repository.GetByIdAsync(id, cancellationToken);
+        if (clinica is null)
+        {
+            return OperationResult.Failure(OperationErrorType.NotFound, "Clínica não encontrada.");
+        }
+
+        var enderecoAtual = clinica.Endereco ?? await _repository.GetEnderecoByClinicaIdAsync(id, cancellationToken);
+
+        clinica.Endereco = enderecoAtual;
+        clinica.ApplyUpdate(dto);
+
+        if (dto.Endereco is null && enderecoAtual is not null)
+        {
+            await _repository.RemoveEnderecoAsync(enderecoAtual, cancellationToken);
+            clinica.Endereco = null;
+        }
+
+        await _repository.UpdateAsync(clinica, cancellationToken);
+        return OperationResult.Success();
+    }
+
+    public async Task<OperationResult> DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var clinica = await _repository.GetByIdAsync(id, cancellationToken);
+        if (clinica is null)
+        {
+            return OperationResult.Failure(OperationErrorType.NotFound, "Clínica não encontrada.");
+        }
+
+        await _repository.DeleteAsync(clinica, cancellationToken);
+        return OperationResult.Success();
+    }
+
+    public async Task<OperationResult<ProfissionalReadDto>> AddProfissionalAsync(int clinicaId, ProfissionalCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        if (!await _repository.ClinicaExistsAsync(clinicaId, cancellationToken))
+        {
+            return OperationResult<ProfissionalReadDto>.Failure(OperationErrorType.NotFound, "Clínica não encontrada.");
+        }
+
+        var entity = dto.ToEntity(clinicaId);
+        var created = await _repository.AddProfissionalAsync(entity, cancellationToken);
+        return OperationResult<ProfissionalReadDto>.Success(created.ToReadDto());
+    }
+
+    public async Task<OperationResult> UpdateProfissionalAsync(int clinicaId, int profissionalId, ProfissionalUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        if (!await _repository.ClinicaExistsAsync(clinicaId, cancellationToken))
+        {
+            return OperationResult.Failure(OperationErrorType.NotFound, "Clínica não encontrada.");
+        }
+
+        var profissional = await _repository.GetProfissionalByIdAsync(profissionalId, clinicaId, cancellationToken);
+        if (profissional is null)
+        {
+            return OperationResult.Failure(OperationErrorType.NotFound, "Profissional não encontrado para a clínica informada.");
+        }
+
+        profissional.ApplyUpdate(dto);
+        await _repository.UpdateProfissionalAsync(profissional, cancellationToken);
+        return OperationResult.Success();
+    }
+}

--- a/CP_05/Domain/Entities/ClinicaEntity.cs
+++ b/CP_05/Domain/Entities/ClinicaEntity.cs
@@ -1,23 +1,20 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
-namespace CP_05.Domain.Entities
+namespace CP_05.Domain.Entities;
+
+public class ClinicaEntity
 {
-    public class ClinicaEntity
-    {
     public int Id { get; set; }
 
     [Required]
-    public string Nome { get; set; } = null!;
+    public string Nome { get; set; } = string.Empty;
 
     [Required, EmailAddress]
-    public string Email { get; set; } = null!;
+    public string Email { get; set; } = string.Empty;
 
     public string? Telefone { get; set; }
 
-    // 1:N
-    public List<ProfissionaisEntity> Profissionais { get; set; } = new();
-
-    // 1:1
     public EnderecoEntity? Endereco { get; set; }
-}
+
+    public List<ProfissionalEntity> Profissionais { get; set; } = new();
 }

--- a/CP_05/Domain/Entities/EnderecoEntity.cs
+++ b/CP_05/Domain/Entities/EnderecoEntity.cs
@@ -1,24 +1,25 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
-namespace CP_05.Domain.Entities
-{
-    public class EnderecoEntity
+namespace CP_05.Domain.Entities;
+
+public class EnderecoEntity
 {
     public int Id { get; set; }
 
     [Required]
-    public string Nome { get; set; } = null!;
-
-    [Required, EmailAddress]
-    public string Email { get; set; } = null!;
+    public string Rua { get; set; } = string.Empty;
 
     [Required]
-    public int Idade { get; set; }
+    public int Numero { get; set; }
 
-    public string? Cargo { get; set; }
+    [Required]
+    public string Bairro { get; set; } = string.Empty;
 
-    // FK 1:N
+    [Required]
+    [Display(Name = "CEP")]
+    public string Cep { get; set; } = string.Empty;
+
     public int ClinicaId { get; set; }
+
     public ClinicaEntity? Clinica { get; set; }
-}
 }

--- a/CP_05/Domain/Entities/ProfissionalEntity.cs
+++ b/CP_05/Domain/Entities/ProfissionalEntity.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CP_05.Domain.Entities;
+
+public class ProfissionalEntity
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Nome { get; set; } = string.Empty;
+
+    [Required, EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [Range(0, int.MaxValue, ErrorMessage = "A idade deve ser um número positivo.")]
+    public int Idade { get; set; }
+
+    public string? Cargo { get; set; }
+
+    public int ClinicaId { get; set; }
+
+    public ClinicaEntity? Clinica { get; set; }
+}

--- a/CP_05/Domain/Interfaces/IClinicaRepository.cs
+++ b/CP_05/Domain/Interfaces/IClinicaRepository.cs
@@ -1,6 +1,20 @@
-﻿namespace CP_05.Domain.Interfaces
+using CP_05.Domain.Entities;
+
+namespace CP_05.Domain.Interfaces;
+
+public interface IClinicaRepository
 {
-    public interface IClinicaRepository
-    {
-    }
+    Task<List<ClinicaEntity>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<ClinicaEntity?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<ClinicaEntity> AddAsync(ClinicaEntity clinica, CancellationToken cancellationToken = default);
+    Task UpdateAsync(ClinicaEntity clinica, CancellationToken cancellationToken = default);
+    Task DeleteAsync(ClinicaEntity clinica, CancellationToken cancellationToken = default);
+
+    Task<bool> ClinicaExistsAsync(int clinicaId, CancellationToken cancellationToken = default);
+    Task<EnderecoEntity?> GetEnderecoByClinicaIdAsync(int clinicaId, CancellationToken cancellationToken = default);
+    Task RemoveEnderecoAsync(EnderecoEntity endereco, CancellationToken cancellationToken = default);
+
+    Task<ProfissionalEntity> AddProfissionalAsync(ProfissionalEntity profissional, CancellationToken cancellationToken = default);
+    Task<ProfissionalEntity?> GetProfissionalByIdAsync(int profissionalId, int clinicaId, CancellationToken cancellationToken = default);
+    Task UpdateProfissionalAsync(ProfissionalEntity profissional, CancellationToken cancellationToken = default);
 }

--- a/CP_05/Infrastructure/Data/ApplicationDbContext.cs
+++ b/CP_05/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,0 +1,57 @@
+using CP_05.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CP_05.Infrastructure.Data;
+
+public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : DbContext(options)
+{
+    public DbSet<ClinicaEntity> Clinicas => Set<ClinicaEntity>();
+    public DbSet<EnderecoEntity> Enderecos => Set<EnderecoEntity>();
+    public DbSet<ProfissionalEntity> Profissionais => Set<ProfissionalEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<ClinicaEntity>(builder =>
+        {
+            builder.ToTable("Clinicas");
+            builder.HasKey(c => c.Id);
+            builder.Property(c => c.Nome).IsRequired().HasMaxLength(150);
+            builder.Property(c => c.Email).IsRequired().HasMaxLength(150);
+            builder.Property(c => c.Telefone).HasMaxLength(30);
+
+            builder.HasOne(c => c.Endereco)
+                .WithOne(e => e.Clinica)
+                .HasForeignKey<EnderecoEntity>(e => e.ClinicaId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(c => c.Profissionais)
+                .WithOne(p => p.Clinica)
+                .HasForeignKey(p => p.ClinicaId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<EnderecoEntity>(builder =>
+        {
+            builder.ToTable("Enderecos");
+            builder.HasKey(e => e.Id);
+            builder.Property(e => e.Rua).IsRequired().HasMaxLength(150);
+            builder.Property(e => e.Numero).IsRequired();
+            builder.Property(e => e.Bairro).IsRequired().HasMaxLength(100);
+            builder.Property(e => e.Cep).IsRequired().HasMaxLength(20);
+        });
+
+        modelBuilder.Entity<ProfissionalEntity>(builder =>
+        {
+            builder.ToTable("Profissionais");
+            builder.HasKey(p => p.Id);
+            builder.Property(p => p.Nome).IsRequired().HasMaxLength(150);
+            builder.Property(p => p.Email).IsRequired().HasMaxLength(150);
+            builder.Property(p => p.Idade).IsRequired();
+            builder.Property(p => p.Cargo).HasMaxLength(100);
+
+            builder.HasIndex(p => new { p.Email, p.ClinicaId }).IsUnique();
+        });
+    }
+}

--- a/CP_05/Infrastructure/Repositories/ClinicaRepository.cs
+++ b/CP_05/Infrastructure/Repositories/ClinicaRepository.cs
@@ -1,0 +1,80 @@
+using CP_05.Domain.Entities;
+using CP_05.Domain.Interfaces;
+using CP_05.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace CP_05.Infrastructure.Repositories;
+
+public class ClinicaRepository(ApplicationDbContext context) : IClinicaRepository
+{
+    private readonly ApplicationDbContext _context = context;
+
+    public async Task<List<ClinicaEntity>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.Clinicas
+            .Include(c => c.Endereco)
+            .Include(c => c.Profissionais)
+            .AsNoTracking()
+            .OrderBy(c => c.Nome)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<ClinicaEntity?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await _context.Clinicas
+            .Include(c => c.Endereco)
+            .Include(c => c.Profissionais)
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+    }
+
+    public async Task<ClinicaEntity> AddAsync(ClinicaEntity clinica, CancellationToken cancellationToken = default)
+    {
+        _context.Clinicas.Add(clinica);
+        await _context.SaveChangesAsync(cancellationToken);
+        return clinica;
+    }
+
+    public async Task UpdateAsync(ClinicaEntity clinica, CancellationToken cancellationToken = default)
+    {
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(ClinicaEntity clinica, CancellationToken cancellationToken = default)
+    {
+        _context.Clinicas.Remove(clinica);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public Task<bool> ClinicaExistsAsync(int clinicaId, CancellationToken cancellationToken = default)
+    {
+        return _context.Clinicas.AnyAsync(c => c.Id == clinicaId, cancellationToken);
+    }
+
+    public async Task<EnderecoEntity?> GetEnderecoByClinicaIdAsync(int clinicaId, CancellationToken cancellationToken = default)
+    {
+        return await _context.Enderecos.FirstOrDefaultAsync(e => e.ClinicaId == clinicaId, cancellationToken);
+    }
+
+    public async Task RemoveEnderecoAsync(EnderecoEntity endereco, CancellationToken cancellationToken = default)
+    {
+        _context.Enderecos.Remove(endereco);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<ProfissionalEntity> AddProfissionalAsync(ProfissionalEntity profissional, CancellationToken cancellationToken = default)
+    {
+        _context.Profissionais.Add(profissional);
+        await _context.SaveChangesAsync(cancellationToken);
+        return profissional;
+    }
+
+    public Task<ProfissionalEntity?> GetProfissionalByIdAsync(int profissionalId, int clinicaId, CancellationToken cancellationToken = default)
+    {
+        return _context.Profissionais.FirstOrDefaultAsync(p => p.Id == profissionalId && p.ClinicaId == clinicaId, cancellationToken);
+    }
+
+    public async Task UpdateProfissionalAsync(ProfissionalEntity profissional, CancellationToken cancellationToken = default)
+    {
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/CP_05/Migrations/20241004120000_InitialCreate.cs
+++ b/CP_05/Migrations/20241004120000_InitialCreate.cs
@@ -1,0 +1,101 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CP_05.Migrations;
+
+public partial class InitialCreate : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Clinicas",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "NUMBER(10)", nullable: false)
+                    .Annotation("Oracle:Identity", "START WITH 1 INCREMENT BY 1"),
+                Nome = table.Column<string>(type: "NVARCHAR2(150)", maxLength: 150, nullable: false),
+                Email = table.Column<string>(type: "NVARCHAR2(150)", maxLength: 150, nullable: false),
+                Telefone = table.Column<string>(type: "NVARCHAR2(30)", maxLength: 30, nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Clinicas", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Enderecos",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "NUMBER(10)", nullable: false)
+                    .Annotation("Oracle:Identity", "START WITH 1 INCREMENT BY 1"),
+                Rua = table.Column<string>(type: "NVARCHAR2(150)", maxLength: 150, nullable: false),
+                Numero = table.Column<int>(type: "NUMBER(10)", nullable: false),
+                Bairro = table.Column<string>(type: "NVARCHAR2(100)", maxLength: 100, nullable: false),
+                Cep = table.Column<string>(type: "NVARCHAR2(20)", maxLength: 20, nullable: false),
+                ClinicaId = table.Column<int>(type: "NUMBER(10)", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Enderecos", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Enderecos_Clinicas_ClinicaId",
+                    column: x => x.ClinicaId,
+                    principalTable: "Clinicas",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Profissionais",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "NUMBER(10)", nullable: false)
+                    .Annotation("Oracle:Identity", "START WITH 1 INCREMENT BY 1"),
+                Nome = table.Column<string>(type: "NVARCHAR2(150)", maxLength: 150, nullable: false),
+                Email = table.Column<string>(type: "NVARCHAR2(150)", maxLength: 150, nullable: false),
+                Idade = table.Column<int>(type: "NUMBER(10)", nullable: false),
+                Cargo = table.Column<string>(type: "NVARCHAR2(100)", maxLength: 100, nullable: true),
+                ClinicaId = table.Column<int>(type: "NUMBER(10)", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Profissionais", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Profissionais_Clinicas_ClinicaId",
+                    column: x => x.ClinicaId,
+                    principalTable: "Clinicas",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Enderecos_ClinicaId",
+            table: "Enderecos",
+            column: "ClinicaId",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Profissionais_ClinicaId",
+            table: "Profissionais",
+            column: "ClinicaId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Profissionais_Email_ClinicaId",
+            table: "Profissionais",
+            columns: new[] { "Email", "ClinicaId" },
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "Enderecos");
+
+        migrationBuilder.DropTable(
+            name: "Profissionais");
+
+        migrationBuilder.DropTable(
+            name: "Clinicas");
+    }
+}

--- a/CP_05/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CP_05/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1,0 +1,146 @@
+using CP_05.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace CP_05.Migrations;
+
+[DbContext(typeof(ApplicationDbContext))]
+partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+{
+    protected override void BuildModel(ModelBuilder modelBuilder)
+    {
+        modelBuilder
+            .HasAnnotation("ProductVersion", "8.0.19");
+
+        modelBuilder.Entity("CP_05.Domain.Entities.ClinicaEntity", b =>
+        {
+            b.Property<int>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("NUMBER(10)")
+                .HasAnnotation("Oracle:Identity", "START WITH 1 INCREMENT BY 1");
+
+            b.Property<string>("Email")
+                .IsRequired()
+                .HasMaxLength(150)
+                .HasColumnType("NVARCHAR2(150)");
+
+            b.Property<string>("Nome")
+                .IsRequired()
+                .HasMaxLength(150)
+                .HasColumnType("NVARCHAR2(150)");
+
+            b.Property<string>("Telefone")
+                .HasMaxLength(30)
+                .HasColumnType("NVARCHAR2(30)");
+
+            b.HasKey("Id");
+
+            b.ToTable("Clinicas");
+        });
+
+        modelBuilder.Entity("CP_05.Domain.Entities.EnderecoEntity", b =>
+        {
+            b.Property<int>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("NUMBER(10)")
+                .HasAnnotation("Oracle:Identity", "START WITH 1 INCREMENT BY 1");
+
+            b.Property<string>("Bairro")
+                .IsRequired()
+                .HasMaxLength(100)
+                .HasColumnType("NVARCHAR2(100)");
+
+            b.Property<string>("Cep")
+                .IsRequired()
+                .HasMaxLength(20)
+                .HasColumnType("NVARCHAR2(20)");
+
+            b.Property<int>("ClinicaId")
+                .HasColumnType("NUMBER(10)");
+
+            b.Property<int>("Numero")
+                .HasColumnType("NUMBER(10)");
+
+            b.Property<string>("Rua")
+                .IsRequired()
+                .HasMaxLength(150)
+                .HasColumnType("NVARCHAR2(150)");
+
+            b.HasKey("Id");
+
+            b.HasIndex("ClinicaId")
+                .IsUnique();
+
+            b.ToTable("Enderecos");
+        });
+
+        modelBuilder.Entity("CP_05.Domain.Entities.ProfissionalEntity", b =>
+        {
+            b.Property<int>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("NUMBER(10)")
+                .HasAnnotation("Oracle:Identity", "START WITH 1 INCREMENT BY 1");
+
+            b.Property<string>("Cargo")
+                .HasMaxLength(100)
+                .HasColumnType("NVARCHAR2(100)");
+
+            b.Property<int>("ClinicaId")
+                .HasColumnType("NUMBER(10)");
+
+            b.Property<string>("Email")
+                .IsRequired()
+                .HasMaxLength(150)
+                .HasColumnType("NVARCHAR2(150)");
+
+            b.Property<int>("Idade")
+                .HasColumnType("NUMBER(10)");
+
+            b.Property<string>("Nome")
+                .IsRequired()
+                .HasMaxLength(150)
+                .HasColumnType("NVARCHAR2(150)");
+
+            b.HasKey("Id");
+
+            b.HasIndex("ClinicaId");
+
+            b.HasIndex("Email", "ClinicaId")
+                .IsUnique();
+
+            b.ToTable("Profissionais");
+        });
+
+        modelBuilder.Entity("CP_05.Domain.Entities.EnderecoEntity", b =>
+        {
+            b.HasOne("CP_05.Domain.Entities.ClinicaEntity", "Clinica")
+                .WithOne("Endereco")
+                .HasForeignKey("CP_05.Domain.Entities.EnderecoEntity", "ClinicaId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+
+            b.Navigation("Clinica");
+        });
+
+        modelBuilder.Entity("CP_05.Domain.Entities.ProfissionalEntity", b =>
+        {
+            b.HasOne("CP_05.Domain.Entities.ClinicaEntity", "Clinica")
+                .WithMany("Profissionais")
+                .HasForeignKey("ClinicaId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+
+            b.Navigation("Clinica");
+        });
+
+        modelBuilder.Entity("CP_05.Domain.Entities.ClinicaEntity", b =>
+        {
+            b.Navigation("Endereco");
+
+            b.Navigation("Profissionais");
+        });
+    }
+}

--- a/CP_05/Presentation/Swagger/ExampleSchemaFilter.cs
+++ b/CP_05/Presentation/Swagger/ExampleSchemaFilter.cs
@@ -1,0 +1,109 @@
+using System;
+using CP_05.Application.Dtos.Clinica;
+using CP_05.Application.Dtos.Endereco;
+using CP_05.Application.Dtos.Profissional;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace CP_05.Presentation.Swagger;
+
+public class ExampleSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        schema.Example = context.Type switch
+        {
+            Type type when type == typeof(ClinicaCreateDto) => BuildClinicaCreateExample(),
+            Type type when type == typeof(ClinicaUpdateDto) => BuildClinicaUpdateExample(),
+            Type type when type == typeof(ClinicaReadDto) => BuildClinicaReadExample(),
+            Type type when type == typeof(EnderecoCreateDto) => BuildEnderecoCreateExample(),
+            Type type when type == typeof(EnderecoUpdateDto) => BuildEnderecoUpdateExample(),
+            Type type when type == typeof(EnderecoReadDto) => BuildEnderecoReadExample(),
+            Type type when type == typeof(ProfissionalCreateDto) => BuildProfissionalCreateExample(),
+            Type type when type == typeof(ProfissionalUpdateDto) => BuildProfissionalUpdateExample(),
+            Type type when type == typeof(ProfissionalReadDto) => BuildProfissionalReadExample(),
+            _ => schema.Example
+        };
+    }
+
+    private static IOpenApiAny BuildClinicaCreateExample() => new OpenApiObject
+    {
+        ["nome"] = new OpenApiString("Clínica Bem-Estar"),
+        ["email"] = new OpenApiString("contato@bemestar.com"),
+        ["telefone"] = new OpenApiString("+55 11 4002-8922"),
+        ["endereco"] = BuildEnderecoCreateExample()
+    };
+
+    private static IOpenApiAny BuildClinicaUpdateExample() => new OpenApiObject
+    {
+        ["nome"] = new OpenApiString("Clínica Bem-Estar Unidade Jardins"),
+        ["email"] = new OpenApiString("contato@bemestar.com"),
+        ["telefone"] = new OpenApiString("+55 11 98877-6655"),
+        ["endereco"] = BuildEnderecoUpdateExample()
+    };
+
+    private static IOpenApiAny BuildClinicaReadExample() => new OpenApiObject
+    {
+        ["id"] = new OpenApiInteger(1),
+        ["nome"] = new OpenApiString("Clínica Bem-Estar"),
+        ["email"] = new OpenApiString("contato@bemestar.com"),
+        ["telefone"] = new OpenApiString("+55 11 4002-8922"),
+        ["endereco"] = BuildEnderecoReadExample(),
+        ["profissionais"] = new OpenApiArray
+        {
+            BuildProfissionalReadExample()
+        }
+    };
+
+    private static IOpenApiAny BuildEnderecoCreateExample() => new OpenApiObject
+    {
+        ["rua"] = new OpenApiString("Av. Paulista"),
+        ["numero"] = new OpenApiInteger(1000),
+        ["bairro"] = new OpenApiString("Bela Vista"),
+        ["cep"] = new OpenApiString("01310-100")
+    };
+
+    private static IOpenApiAny BuildEnderecoUpdateExample() => new OpenApiObject
+    {
+        ["rua"] = new OpenApiString("Av. Brigadeiro Faria Lima"),
+        ["numero"] = new OpenApiInteger(4500),
+        ["bairro"] = new OpenApiString("Itaim Bibi"),
+        ["cep"] = new OpenApiString("04538-132")
+    };
+
+    private static IOpenApiAny BuildEnderecoReadExample() => new OpenApiObject
+    {
+        ["id"] = new OpenApiInteger(1),
+        ["rua"] = new OpenApiString("Av. Paulista"),
+        ["numero"] = new OpenApiInteger(1000),
+        ["bairro"] = new OpenApiString("Bela Vista"),
+        ["cep"] = new OpenApiString("01310-100")
+    };
+
+    private static IOpenApiAny BuildProfissionalCreateExample() => new OpenApiObject
+    {
+        ["nome"] = new OpenApiString("Maria Souza"),
+        ["email"] = new OpenApiString("maria.souza@exemplo.com"),
+        ["idade"] = new OpenApiInteger(32),
+        ["cargo"] = new OpenApiString("Fisioterapeuta")
+    };
+
+    private static IOpenApiAny BuildProfissionalUpdateExample() => new OpenApiObject
+    {
+        ["nome"] = new OpenApiString("Maria Souza"),
+        ["email"] = new OpenApiString("maria.souza@exemplo.com"),
+        ["idade"] = new OpenApiInteger(33),
+        ["cargo"] = new OpenApiString("Coordenadora Clínica")
+    };
+
+    private static IOpenApiAny BuildProfissionalReadExample() => new OpenApiObject
+    {
+        ["id"] = new OpenApiInteger(10),
+        ["nome"] = new OpenApiString("Maria Souza"),
+        ["email"] = new OpenApiString("maria.souza@exemplo.com"),
+        ["idade"] = new OpenApiInteger(32),
+        ["cargo"] = new OpenApiString("Fisioterapeuta"),
+        ["clinicaId"] = new OpenApiInteger(1)
+    };
+}

--- a/CP_05/Program.cs
+++ b/CP_05/Program.cs
@@ -1,12 +1,26 @@
+using CP_05.Application.Interfaces;
+using CP_05.Application.UseCases;
+using CP_05.Domain.Interfaces;
+using CP_05.Infrastructure.Data;
+using CP_05.Infrastructure.Repositories;
+using CP_05.Presentation.Swagger;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseOracle(builder.Configuration.GetConnectionString("Oracle")));
+
+builder.Services.AddScoped<IClinicaRepository, ClinicaRepository>();
+builder.Services.AddScoped<IClinicaUseCase, ClinicaUseCase>();
 
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(option => { 
+builder.Services.AddSwaggerGen(option =>
+{
     option.EnableAnnotations();
+    option.SchemaFilter<ExampleSchemaFilter>();
 });
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary
- add application DTOs, mappers, operation results, and use case orchestration for clínicas and profissionais
- implement Oracle-backed EF Core context, repository pattern, and initial migration reflecting the required relationships
- update the clínicas controller with full CRUD, professional management endpoints, and Swagger examples, and wire up dependency injection and Swagger configuration

## Testing
- Not run (dotnet CLI not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e04f013310833396c80e6c38c7526b